### PR TITLE
✨ feat(identity): Implement GetPluginInfo

### DIFF
--- a/emptyDirClone/Makefile
+++ b/emptyDirClone/Makefile
@@ -101,12 +101,13 @@ kind-load: ## Load docker image with the plugin, into Kind cluster targeted by t
 
 .PHONY: deploy
 deploy: ## Deploy the plugin to the K8s cluster specified in $KUBECONFIG.
-
-	kubectl apply --file deploy
+	@kubectl apply --filename deploy \
+		|| { sleep 1; kubectl apply --filename deploy; }
 
 .PHONY: undeploy
 undeploy: ## Undeploy the plugin from the K8s cluster specified in $KUBECONFIG.
-	kubectl delete --file deploy
+	@kubectl delete --filename deploy \
+		|| sleep 1
 
 ## Helpers
 

--- a/emptyDirClone/internal/emptydirclone/emptydirclone.go
+++ b/emptyDirClone/internal/emptydirclone/emptydirclone.go
@@ -14,7 +14,9 @@ import (
 )
 
 type Config struct {
-	Endpoint string
+	Name          string
+	Endpoint      string
+	VendorVersion string
 }
 
 type emptyDirClone struct {

--- a/emptyDirClone/internal/emptydirclone/identityserver.go
+++ b/emptyDirClone/internal/emptydirclone/identityserver.go
@@ -7,7 +7,10 @@ import (
 )
 
 func (e *emptyDirClone) GetPluginInfo(context.Context, *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
-	return &csi.GetPluginInfoResponse{}, nil
+	return &csi.GetPluginInfoResponse{
+		Name:          e.config.Name,
+		VendorVersion: e.config.VendorVersion,
+	}, nil
 }
 
 func (e *emptyDirClone) GetPluginCapabilities(context.Context, *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {

--- a/emptyDirClone/main.go
+++ b/emptyDirClone/main.go
@@ -9,8 +9,10 @@ import (
 var version string
 
 func main() {
+	const (
+		pluginname = "emptydirclone.mriyam.dev"
+	)
 	var endpoint string
-
 	flag.StringVar(&endpoint, "endpoint", "unix:/csi/csi.sock", "Endpoint for the gRPC server to listen on. Default: \"unix:/csi/csi.sock\"")
 	flag.Parse()
 
@@ -19,7 +21,9 @@ func main() {
 	}
 
 	cfg := emptydirclone.Config{
-		Endpoint: endpoint,
+		Name:          pluginname,
+		Endpoint:      endpoint,
+		VendorVersion: version,
 	}
 
 	emptydirclone := emptydirclone.New(cfg)


### PR DESCRIPTION
Closes #24 

## Before implementation

Logs from the plugin
```sh
$ make logs
emptydirclone-plugin-r9mh9 node-driver-registrar I1227 16:42:08.856290       1 main.go:135] Version: v2.9.2
emptydirclone-plugin-r9mh9 node-driver-registrar I1227 16:42:08.856322       1 main.go:136] Running node-driver-registrar in mode=
emptydirclone-plugin-r9mh9 node-driver-registrar I1227 16:42:08.856326       1 main.go:157] Attempting to open a gRPC connection with: "/csi/csi.sock"
emptydirclone-plugin-r9mh9 node-driver-registrar I1227 16:42:08.856701       1 main.go:164] Calling CSI driver to discover driver name
emptydirclone-plugin-r9mh9 node-driver-registrar E1227 16:42:08.857655       1 main.go:170] error retreiving CSI driver name: driver name is empty
```

## After implementation

Logs from the plugin
```sh
$ make logs
emptydirclone-plugin-pljc8 node-driver-registrar I1227 16:42:31.361083       1 main.go:135] Version: v2.9.2
emptydirclone-plugin-pljc8 node-driver-registrar I1227 16:42:31.361117       1 main.go:136] Running node-driver-registrar in mode=
emptydirclone-plugin-pljc8 node-driver-registrar I1227 16:42:31.361121       1 main.go:157] Attempting to open a gRPC connection with: "/csi/csi.sock"
emptydirclone-plugin-pljc8 node-driver-registrar I1227 16:42:31.361513       1 main.go:164] Calling CSI driver to discover driver name
emptydirclone-plugin-pljc8 node-driver-registrar I1227 16:42:31.362819       1 main.go:173] CSI driver name: "emptydirclone.mriyam.dev"
emptydirclone-plugin-pljc8 node-driver-registrar I1227 16:42:31.362836       1 node_register.go:55] Starting Registration Server at: /registration/emptydirclone.mriyam.dev-reg.sock
emptydirclone-plugin-pljc8 node-driver-registrar I1227 16:42:31.362895       1 node_register.go:64] Registration Server started at: /registration/emptydirclone.mriyam.dev-reg.sock
emptydirclone-plugin-pljc8 node-driver-registrar I1227 16:42:31.362981       1 node_register.go:88] Skipping HTTP server because endpoint is set to: ""
emptydirclone-plugin-pljc8 node-driver-registrar I1227 16:42:32.348759       1 main.go:90] Received GetInfo call: &InfoRequest{}
emptydirclone-plugin-pljc8 node-driver-registrar I1227 16:42:32.361728       1 main.go:101] Received NotifyRegistrationStatus call: &RegistrationStatus{PluginRegistered:false,Error:RegisterPlugin error -- plugin registration failed with err: error adding CSI driver node info: driverNodeID must not be empty,}
emptydirclone-plugin-pljc8 node-driver-registrar E1227 16:42:32.361790       1 main.go:103] Registration process failed with error: RegisterPlugin error -- plugin registration failed with err: error adding CSI driver node info: driverNodeID must not be empty, restarting registration container.
```