### PR TITLE
✨ feat(node): Implement `NodePublishVolume`

### DIFF
--- a/emptyDirClone/.gitignore
+++ b/emptyDirClone/.gitignore
@@ -1,2 +1,4 @@
 bin/
 test.sock
+tests/e2e/logs/
+tests/e2e/kubeconfig.yaml

--- a/emptyDirClone/Makefile
+++ b/emptyDirClone/Makefile
@@ -14,6 +14,10 @@ TAG ?= latest
 VERSION ?= $(GIT_INFO)
 # Namespace to deploy the CSI plugin
 CSI_NAMESPACE ?= emptydirclone
+# E2E Test args
+ifdef E2E_TEST_ARGS
+E2E_ARGS = --args $(E2E_TEST_ARGS)
+endif
 
 ##@ General
 
@@ -58,7 +62,7 @@ csc-test: fmt vet build ## Run `csc` tests.
 
 .PHONY: e2e
 e2e: fmt vet ## Run e2e tests.
-	go test ./tests/e2e -v
+	env KUBECONFIG=${PWD}/tests/e2e/kubeconfig.yaml go test ./tests/e2e -test.v $(E2E_ARGS)
 
 
 STERN_EXISTS := $(shell stern --version 2>/dev/null)

--- a/emptyDirClone/Makefile
+++ b/emptyDirClone/Makefile
@@ -12,6 +12,8 @@ IMG ?= ghcr.io/mbtamuli/csi-quickstart/emptydirclone
 TAG ?= latest
 # Version of the application
 VERSION ?= $(GIT_INFO)
+# Namespace to deploy the CSI plugin
+CSI_NAMESPACE ?= emptydirclone
 
 ##@ General
 
@@ -101,13 +103,13 @@ kind-load: ## Load docker image with the plugin, into Kind cluster targeted by t
 
 .PHONY: deploy
 deploy: ## Deploy the plugin to the K8s cluster specified in $KUBECONFIG.
-	@kubectl apply --filename deploy \
-		|| { sleep 1; kubectl apply --filename deploy; }
+	@kubectl create namespace $(CSI_NAMESPACE) \
+		&& kubectl config set-context $(kubectl config current-context) --namespace=$(CSI_NAMESPACE) \
+		&& kubectl apply --filename deploy
 
 .PHONY: undeploy
 undeploy: ## Undeploy the plugin from the K8s cluster specified in $KUBECONFIG.
-	@kubectl delete --filename deploy \
-		|| sleep 1
+	@kubectl delete --filename deploy
 
 ## Helpers
 

--- a/emptyDirClone/deploy/csidriver.yaml
+++ b/emptyDirClone/deploy/csidriver.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: emptydirclone.mriyam.dev
+spec:
+  attachRequired: false
+  volumeLifecycleModes:
+  - Ephemeral

--- a/emptyDirClone/deploy/daemonset.yaml
+++ b/emptyDirClone/deploy/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--environment=development"
             - "--nodeid=$(KUBE_NODE_NAME)"
-            - "--verbosity=-10"
+            - "--verbosity=-2"
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
@@ -65,7 +65,7 @@ spec:
             type: Directory
           name: kubelet-registration-dir
         - hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet
             type: DirectoryOrCreate
           name: kubelet-dir
         - hostPath:

--- a/emptyDirClone/deploy/daemonset.yaml
+++ b/emptyDirClone/deploy/daemonset.yaml
@@ -19,11 +19,17 @@ spec:
           image: ghcr.io/mbtamuli/csi-quickstart/emptydirclone:debug
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--verbosity=-10"
             - "--environment=development"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--verbosity=-10"
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
           securityContext:
             privileged: true
           volumeMounts:

--- a/emptyDirClone/deploy/namespace.yaml
+++ b/emptyDirClone/deploy/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: emptydirclone

--- a/emptyDirClone/example/pod-inline.yaml
+++ b/emptyDirClone/example/pod-inline.yaml
@@ -1,0 +1,17 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: my-csi-app
+spec:
+  terminationGracePeriodSeconds: 0
+  containers:
+    - name: my-frontend
+      image: busybox:1.28
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-inline-vol
+      command: [ "sleep", "1000000" ]
+  volumes:
+    - name: my-csi-inline-vol
+      csi:
+        driver: emptydirclone.mriyam.dev

--- a/emptyDirClone/go.mod
+++ b/emptyDirClone/go.mod
@@ -6,11 +6,12 @@ require (
 	github.com/container-storage-interface/spec v1.9.0
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.2.4
-	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1
+	github.com/golang/glog v1.1.0
 	go.uber.org/zap v1.25.0
 	google.golang.org/grpc v1.57.0
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
+	k8s.io/mount-utils v0.29.0
 	sigs.k8s.io/e2e-framework v0.3.0
 )
 
@@ -32,6 +33,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -40,6 +42,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vladimirvivien/gexe v0.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/emptyDirClone/go.sum
+++ b/emptyDirClone/go.sum
@@ -34,6 +34,8 @@ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEe
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
+github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
@@ -54,8 +56,6 @@ github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1 h1:HcUWd006luQPljE73d5sk+/VgYPGUReEVz2y1/qylwY=
-github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1/go.mod h1:w9Y7gY31krpLmrVU5ZPG9H7l9fZuRu5/3R3S3FMtVQ4=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -77,6 +77,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zk
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
+github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
+github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -231,6 +233,8 @@ k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
 k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
 k8s.io/kube-openapi v0.0.0-20231214164306-ab13479f8bf8 h1:yHNkNuLjht7iq95pO9QmbjOWCguvn8mDe3lT78nqPkw=
 k8s.io/kube-openapi v0.0.0-20231214164306-ab13479f8bf8/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
+k8s.io/mount-utils v0.29.0 h1:KcUE0bFHONQC10V3SuLWQ6+l8nmJggw9lKLpDftIshI=
+k8s.io/mount-utils v0.29.0/go.mod h1:N3lDK/G1B8R/IkAt4NhHyqB07OqEr7P763z3TNge94U=
 k8s.io/utils v0.0.0-20231127182322-b307cd553661 h1:FepOBzJ0GXm8t0su67ln2wAZjbQ6RxQGZDnzuLcrUTI=
 k8s.io/utils v0.0.0-20231127182322-b307cd553661/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigwG62c4=

--- a/emptyDirClone/internal/emptydirclone/emptydirclone.go
+++ b/emptyDirClone/internal/emptydirclone/emptydirclone.go
@@ -1,6 +1,7 @@
 package emptydirclone
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -15,8 +16,9 @@ import (
 )
 
 type Config struct {
-	Name          string
 	Endpoint      string
+	Name          string
+	NodeID        string
 	VendorVersion string
 }
 
@@ -25,11 +27,23 @@ type emptyDirClone struct {
 	logger logr.Logger
 }
 
-func New(config Config, logger logr.Logger) *emptyDirClone {
+func New(config Config, logger logr.Logger) (*emptyDirClone, error) {
+	if config.Name == "" {
+		return nil, errors.New("no driver name provided")
+	}
+
+	if config.NodeID == "" {
+		return nil, errors.New("no node id provided")
+	}
+
+	if config.Endpoint == "" {
+		return nil, errors.New("no driver endpoint provided")
+	}
+
 	return &emptyDirClone{
 		config: config,
 		logger: logger.WithName("emptydirclone"),
-	}
+	}, nil
 }
 
 func (e *emptyDirClone) Serve() error {

--- a/emptyDirClone/internal/emptydirclone/nodeserver.go
+++ b/emptyDirClone/internal/emptydirclone/nodeserver.go
@@ -6,12 +6,10 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
-func (e *emptyDirClone) NodeStageVolume(context.Context, *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
-	return &csi.NodeStageVolumeResponse{}, nil
-}
-
-func (e *emptyDirClone) NodeUnstageVolume(context.Context, *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
-	return &csi.NodeUnstageVolumeResponse{}, nil
+func (e *emptyDirClone) NodeGetInfo(context.Context, *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	return &csi.NodeGetInfoResponse{
+		NodeId: e.config.NodeID,
+	}, nil
 }
 
 func (e *emptyDirClone) NodePublishVolume(context.Context, *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
@@ -20,6 +18,16 @@ func (e *emptyDirClone) NodePublishVolume(context.Context, *csi.NodePublishVolum
 
 func (e *emptyDirClone) NodeUnpublishVolume(context.Context, *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	return &csi.NodeUnpublishVolumeResponse{}, nil
+}
+
+// The following methods are kept to satisfy the interface `csi.NodeServer`
+
+func (e *emptyDirClone) NodeStageVolume(context.Context, *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+func (e *emptyDirClone) NodeUnstageVolume(context.Context, *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
 func (e *emptyDirClone) NodeGetVolumeStats(context.Context, *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
@@ -32,8 +40,4 @@ func (e *emptyDirClone) NodeExpandVolume(context.Context, *csi.NodeExpandVolumeR
 
 func (e *emptyDirClone) NodeGetCapabilities(context.Context, *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	return &csi.NodeGetCapabilitiesResponse{}, nil
-}
-
-func (e *emptyDirClone) NodeGetInfo(context.Context, *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	return &csi.NodeGetInfoResponse{}, nil
 }

--- a/emptyDirClone/internal/log/logger.go
+++ b/emptyDirClone/internal/log/logger.go
@@ -1,15 +1,12 @@
 package log
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"google.golang.org/grpc"
 )
 
 func SetupLogger(level int, environment string) logr.Logger {
@@ -27,55 +24,4 @@ func SetupLogger(level int, environment string) logr.Logger {
 		panic(fmt.Sprintf("who watches the watchmen (%v)?", err))
 	}
 	return zapr.NewLogger(zapLog)
-}
-
-func GRPCOpts(debug bool, logger logr.Logger) []grpc.ServerOption {
-	var opts []grpc.ServerOption
-
-	if debug {
-		opts = append(opts, grpc.ChainUnaryInterceptor(
-			logging.UnaryServerInterceptor(
-				interceptorLogger(logger),
-				[]logging.Option{
-					logging.WithLogOnEvents(
-						logging.StartCall,
-						logging.FinishCall,
-						logging.PayloadReceived,
-						logging.PayloadSent,
-					),
-				}...),
-		))
-	} else {
-		opts = append(opts, grpc.ChainUnaryInterceptor(
-			logging.UnaryServerInterceptor(
-				interceptorLogger(logger),
-				[]logging.Option{
-					logging.WithLogOnEvents(
-						logging.FinishCall,
-					),
-				}...),
-		))
-	}
-
-	return opts
-}
-
-// interceptorLogger adapts logr logger to interceptor logger.
-// This code is simple enough to be copied and not imported.
-func interceptorLogger(l logr.Logger) logging.Logger {
-	return logging.LoggerFunc(func(_ context.Context, lvl logging.Level, msg string, fields ...any) {
-		l := l.WithName("gRPCLogger").WithValues(fields...)
-		switch lvl {
-		case logging.LevelDebug:
-			l.V(int(logging.LevelDebug)).Info(msg)
-		case logging.LevelInfo:
-			l.V(int(logging.LevelInfo)).Info(msg)
-		case logging.LevelWarn:
-			l.V(int(logging.LevelWarn)).Info(msg)
-		case logging.LevelError:
-			l.V(int(logging.LevelError)).Info(msg)
-		default:
-			panic(fmt.Sprintf("unknown level %v", lvl))
-		}
-	})
 }

--- a/emptyDirClone/main.go
+++ b/emptyDirClone/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/go-logr/logr"
 	"github.com/mbtamuli/emptyDirClone/internal/emptydirclone"
@@ -20,11 +21,13 @@ func main() {
 		level       int
 		environment string
 		endpoint    string
+		nodeid      string
 	)
 
 	flag.IntVar(&level, "verbosity", 0, "Log level verbosity. Lower is verbose and less imporant. Higher is quiet and more important. Default: 0; Valid options: -128 to 128")
 	flag.StringVar(&environment, "environment", "production", "Environment the application is run in. Default: \"production\"; Valid options: \"production\", \"development\"")
 	flag.StringVar(&endpoint, "endpoint", "unix:///csi/csi.sock", "Endpoint for the gRPC server to listen on. Default: \"unix:///csi/csi.sock\"")
+	flag.StringVar(&nodeid, "nodeid", "", "Kubernetes Node ID")
 	flag.Parse()
 
 	logger = log.SetupLogger(level, environment)
@@ -34,13 +37,20 @@ func main() {
 	}
 
 	cfg := emptydirclone.Config{
-		Name:          pluginname,
 		Endpoint:      endpoint,
+		Name:          pluginname,
+		NodeID:        nodeid,
 		VendorVersion: version,
 	}
 
-	emptydirclone := emptydirclone.New(cfg, logger)
+	emptydirclone, err := emptydirclone.New(cfg, logger)
+	if err != nil {
+		logger.Error(err, "unable to set up the plugin")
+		os.Exit(1)
+	}
+
 	if err := emptydirclone.Serve(); err != nil {
-		panic(err)
+		logger.Error(err, "unable to start the plugin")
+		os.Exit(1)
 	}
 }

--- a/emptyDirClone/tests/e2e/main_test.go
+++ b/emptyDirClone/tests/e2e/main_test.go
@@ -1,9 +1,19 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/decoder"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
@@ -17,20 +27,77 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	cfg, _ := envconf.NewFromFlags()
+	var (
+		csiNamespace       = "emptydirclone"
+		csiPluginImage     = "ghcr.io/mbtamuli/csi-quickstart/emptydirclone:debug"
+		csiPluginPodLabels = map[string]string{"app": "emptydirclone-plugin"}
+		cfg, _             = envconf.NewFromFlags()
+	)
+
 	testEnv = env.NewWithConfig(cfg)
 	kindClusterName = envconf.RandomName("csi", 10)
 	namespace = envconf.RandomName("emptydirclone", 20)
 
 	testEnv.Setup(
 		envfuncs.CreateCluster(kind.NewProvider(), kindClusterName),
+		envfuncs.CreateNamespace(csiNamespace),
+		envfuncs.LoadDockerImageToCluster(kindClusterName, csiPluginImage),
+		deployEmptyDirClone(csiNamespace, csiPluginPodLabels),
 		envfuncs.CreateNamespace(namespace),
 	)
 
 	testEnv.Finish(
-		envfuncs.DeleteNamespace(namespace),
+		envfuncs.ExportClusterLogs(kindClusterName, fmt.Sprintf("logs/cluster-logs-%s", kindClusterName)),
 		envfuncs.DestroyCluster(kindClusterName),
 	)
 
 	os.Exit(testEnv.Run(m))
+}
+
+func deployEmptyDirClone(namespace string, labels map[string]string) env.Func {
+	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+		decoder.ApplyWithManifestDir(
+			ctx,
+			cfg.Client().Resources(),
+			"../../deploy",
+			"*",
+			[]resources.CreateOption{},
+		)
+
+		pods := &v1.PodList{
+			Items: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Labels:    labels,
+					},
+				},
+			},
+		}
+		// wait for the pods to be Ready
+		if err := wait.For(
+			conditions.New(cfg.Client().Resources()).
+				ResourcesMatch(pods,
+					func(object k8s.Object) bool {
+						// phase := object.(*v1.Pod).Status.Phase
+						// fmt.Println("Current Phase of the pod resource", "phase", phase)
+						// return phase == v1.PodRunning
+
+						status := object.(*v1.Pod).Status
+						fmt.Println("Current Status of the pod resource", "status", status)
+						for _, cond := range status.Conditions {
+							if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+								return true
+							}
+						}
+						return false
+					},
+				),
+			wait.WithInterval(time.Second*15),
+			wait.WithTimeout(time.Minute*2)); err != nil {
+			return ctx, err
+		}
+
+		return ctx, nil
+	}
 }

--- a/emptyDirClone/tests/e2e/volume_test.go
+++ b/emptyDirClone/tests/e2e/volume_test.go
@@ -62,6 +62,7 @@ func TestEmptyDirClone(t *testing.T) {
 			// wait for the pod to be in 'Running' phase
 			err = wait.For(conditions.New(client.Resources()).ResourceMatch(&found, func(object k8s.Object) bool {
 				p := object.(*v1.Pod)
+				t.Log(p.Status.Phase)
 				return p.Status.Phase == v1.PodRunning
 			}), wait.WithTimeout(time.Second*30))
 			if err != nil {
@@ -117,6 +118,7 @@ func TestEmptyDirClone(t *testing.T) {
 }
 
 func newPod(namespace string, name string) *v1.Pod {
+	gracePeriod := int64(0)
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -126,6 +128,7 @@ func newPod(namespace string, name string) *v1.Pod {
 			},
 		},
 		Spec: v1.PodSpec{
+			TerminationGracePeriodSeconds: &gracePeriod,
 			Containers: []v1.Container{
 				{
 					Name:  "csi-volume-test",


### PR DESCRIPTION
Closes #25 


# Test run
```
➜  emptyDirClone git:(impl_NodePublishVolume) ✗ make e2e
go fmt ./...
go vet ./...
env KUBECONFIG=/Users/mbtamuli/Documents/Code/csi-quickstart/emptyDirClone/tests/e2e/kubeconfig.yaml go test ./tests/e2e -test.v
=== RUN   TestEmptyDirClone
=== RUN   TestEmptyDirClone/emptyDirClone
=== RUN   TestEmptyDirClone/emptyDirClone/pod_is_running
    volume_test.go:65: Pending
    volume_test.go:65: Pending
    volume_test.go:65: Pending
    volume_test.go:65: Running
=== RUN   TestEmptyDirClone/emptyDirClone/single_container_is_able_to_read/write
=== RUN   TestEmptyDirClone/emptyDirClone/two_containers_are_able_to_read/write
--- PASS: TestEmptyDirClone (30.06s)
    --- PASS: TestEmptyDirClone/emptyDirClone (30.06s)
        --- PASS: TestEmptyDirClone/emptyDirClone/pod_is_running (20.01s)
        --- PASS: TestEmptyDirClone/emptyDirClone/single_container_is_able_to_read/write (5.01s)
        --- PASS: TestEmptyDirClone/emptyDirClone/two_containers_are_able_to_read/write (5.01s)
PASS
ok  	github.com/mbtamuli/emptyDirClone/tests/e2e	77.880s
```